### PR TITLE
Update target frameworks

### DIFF
--- a/ResgateIO.Client.UnitTests/ResgateIO.Client.UnitTests.csproj
+++ b/ResgateIO.Client.UnitTests/ResgateIO.Client.UnitTests.csproj
@@ -1,9 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ResgateIO.Client/ResgateIO.Client.csproj
+++ b/ResgateIO.Client/ResgateIO.Client.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net481</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <PackageId>ResgateIO.Client</PackageId>
     <Version>0.1.2</Version>
     <Title>RES Client .NET library</Title>


### PR DESCRIPTION
For the main library project it makes little sense to target a specific .NET Framework version while also targeting .NET Standard.