### PR TITLE
Expose event for connection status changes

### DIFF
--- a/ResgateIO.Client.UnitTests/mocks/MockWebSocket.cs
+++ b/ResgateIO.Client.UnitTests/mocks/MockWebSocket.cs
@@ -1,9 +1,6 @@
-﻿using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using Xunit.Abstractions;
 
@@ -11,14 +8,14 @@ namespace ResgateIO.Client.UnitTests
 {
     public class MockWebSocket : IWebSocket
     {
-        public event EventHandler<MessageEventArgs> OnMessage;
+        public event EventHandler<MessageEventArgs> MessageReceived;
         public event EventHandler OnClose;
 
         private readonly ITestOutputHelper log;
-        private HashSet<int> requestIds = new HashSet<int>();
-        private Queue<MockRequest> requestQueue = new Queue<MockRequest>();
-        private Queue<TaskCompletionSource<MockRequest>> awaiters = new Queue<TaskCompletionSource<MockRequest>>();
-        private object requestLock = new object();
+        private readonly HashSet<int> requestIds = new HashSet<int>();
+        private readonly Queue<MockRequest> requestQueue = new Queue<MockRequest>();
+        private readonly Queue<TaskCompletionSource<MockRequest>> awaiters = new Queue<TaskCompletionSource<MockRequest>>();
+        private readonly object requestLock = new object();
         private bool Closed = false;
 
         public MockWebSocket(ITestOutputHelper output)
@@ -81,10 +78,7 @@ namespace ResgateIO.Client.UnitTests
         public void SendMessage(byte[] data)
         {
             log?.WriteLine("--> {0}", Encoding.UTF8.GetString(data));
-            OnMessage.Invoke(this, new MessageEventArgs
-            {
-                Message = data,
-            });
+            MessageReceived.Invoke(this, new MessageEventArgs(data));
         }
 
         public async Task<MockRequest> GetRequestAsync()

--- a/ResgateIO.Client.UnitTests/mocks/MockWebSocket.cs
+++ b/ResgateIO.Client.UnitTests/mocks/MockWebSocket.cs
@@ -9,7 +9,7 @@ namespace ResgateIO.Client.UnitTests
     public class MockWebSocket : IWebSocket
     {
         public event EventHandler<MessageEventArgs> MessageReceived;
-        public event EventHandler OnClose;
+        public event EventHandler<ConnectionStatusEventArgs> ConnectionStatusChanged;
 
         private readonly ITestOutputHelper log;
         private readonly HashSet<int> requestIds = new HashSet<int>();
@@ -43,7 +43,8 @@ namespace ResgateIO.Client.UnitTests
 
                 if (requestIds.Contains(request.Id))
                 {
-                    throw new InvalidOperationException(String.Format("Request ID {0} sent more than once for the same connection.", request.Id));
+                    throw new InvalidOperationException(
+                        $"Request ID {request.Id} sent more than once for the same connection.");
                 }
 
                 if (awaiters.Count == 0)
@@ -71,7 +72,7 @@ namespace ResgateIO.Client.UnitTests
                 Closed = true;
             }
             log?.WriteLine("<-X Disconnected");
-            OnClose?.Invoke(this, EventArgs.Empty);
+            ConnectionStatusChanged?.Invoke(this, new ConnectionStatusEventArgs(ConnectionStatus.DisconnectedGracefully));
             return Task.CompletedTask;
         }
 

--- a/ResgateIO.Client/ConnectionStatus.cs
+++ b/ResgateIO.Client/ConnectionStatus.cs
@@ -1,0 +1,9 @@
+﻿namespace ResgateIO.Client
+{
+    public enum ConnectionStatus
+    {
+        Connected,
+        DisconnectedGracefully,
+        DisconnectedWithError
+    }
+}

--- a/ResgateIO.Client/ConnectionStatusEventArgs.cs
+++ b/ResgateIO.Client/ConnectionStatusEventArgs.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace ResgateIO.Client
+{
+    public class ConnectionStatusEventArgs : EventArgs
+    {
+        public ConnectionStatus ConnectionStatus { get; }
+
+        public ConnectionStatusEventArgs(ConnectionStatus connectionStatus)
+        {
+            ConnectionStatus = connectionStatus;
+        }
+    }
+}

--- a/ResgateIO.Client/IResClient.cs
+++ b/ResgateIO.Client/IResClient.cs
@@ -10,7 +10,7 @@ namespace ResgateIO.Client
         event EventHandler<ResourceEventArgs> ResourceEvent;
         event ErrorEventHandler Error;
         string ResgateProtocol { get; }
-        bool Connected { get; }
+        bool IsConnected { get; }
         ResClient SetSerializerSettings(JsonSerializerSettings settings);
         ResClient SetOnConnect(Func<ResClient, Task> callback);
         ResClient SetReconnectDelay(int milliseconds);

--- a/ResgateIO.Client/IResClient.cs
+++ b/ResgateIO.Client/IResClient.cs
@@ -9,6 +9,7 @@ namespace ResgateIO.Client
     {
         event EventHandler<ResourceEventArgs> ResourceEvent;
         event ErrorEventHandler Error;
+        event EventHandler<ConnectionStatusEventArgs> ConnectionStatusChanged;
         string ResgateProtocol { get; }
         bool IsConnected { get; }
         ResClient SetSerializerSettings(JsonSerializerSettings settings);

--- a/ResgateIO.Client/IWebSocket.cs
+++ b/ResgateIO.Client/IWebSocket.cs
@@ -1,22 +1,13 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace ResgateIO.Client
 {
-    public class MessageEventArgs : EventArgs
-    {
-        public byte[] Message { get; set; }
-    }
-
     public interface IWebSocket : IDisposable
     {
-        event EventHandler<MessageEventArgs> OnMessage;
+        event EventHandler<MessageEventArgs> MessageReceived;
         event EventHandler OnClose;
         Task SendAsync(byte[] data);
-        
         Task DisconnectAsync();
     }
 }

--- a/ResgateIO.Client/IWebSocket.cs
+++ b/ResgateIO.Client/IWebSocket.cs
@@ -6,7 +6,7 @@ namespace ResgateIO.Client
     public interface IWebSocket : IDisposable
     {
         event EventHandler<MessageEventArgs> MessageReceived;
-        event EventHandler OnClose;
+        event EventHandler<ConnectionStatusEventArgs> ConnectionStatusChanged;
         Task SendAsync(byte[] data);
         Task DisconnectAsync();
     }

--- a/ResgateIO.Client/MessageEventArgs.cs
+++ b/ResgateIO.Client/MessageEventArgs.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace ResgateIO.Client
+{
+    public class MessageEventArgs : EventArgs
+    {
+        public byte[] Message { get; }
+
+        public MessageEventArgs(byte[] message)
+        {
+            Message = message;
+        }
+    }
+}

--- a/ResgateIO.Client/RequestResult.cs
+++ b/ResgateIO.Client/RequestResult.cs
@@ -1,0 +1,9 @@
+﻿using Newtonsoft.Json.Linq;
+
+namespace ResgateIO.Client
+{
+    class RequestResult
+    {
+        public JToken Result;
+    }
+}

--- a/ResgateIO.Client/ResClient.cs
+++ b/ResgateIO.Client/ResClient.cs
@@ -42,7 +42,7 @@ namespace ResgateIO.Client
         /// </summary>
         public string ResgateProtocol { get; private set; }
 
-        public bool Connected => _rpc != null;
+        public bool IsConnected => _rpc != null;
 
         public ResClient(string hostUrl)
         {

--- a/ResgateIO.Client/ResRpc.cs
+++ b/ResgateIO.Client/ResRpc.cs
@@ -29,10 +29,10 @@ namespace ResgateIO.Client
         {
             WebSocket = ws;
             _serializerSettings = serializerSettings;
-            WebSocket.OnMessage += OnMessage;
+            WebSocket.MessageReceived += WebSocket_MessageReceived;
         }
 
-        private void OnMessage(object sender, MessageEventArgs e)
+        private void WebSocket_MessageReceived(object sender, MessageEventArgs e)
         {
             string msg = null;
             MessageDto rpcmsg = null;

--- a/ResgateIO.Client/ResRpc.cs
+++ b/ResgateIO.Client/ResRpc.cs
@@ -25,10 +25,10 @@ namespace ResgateIO.Client
 
         public IWebSocket WebSocket { get; }
 
-        public ResRpc(IWebSocket ws, JsonSerializerSettings serializerSettings)
+        public ResRpc(IWebSocket webSocket, JsonSerializerSettings serializerSettings)
         {
-            WebSocket = ws;
             _serializerSettings = serializerSettings;
+            WebSocket = webSocket;
             WebSocket.MessageReceived += WebSocket_MessageReceived;
         }
 

--- a/ResgateIO.Client/RpcRequest.cs
+++ b/ResgateIO.Client/RpcRequest.cs
@@ -1,0 +1,16 @@
+﻿using Newtonsoft.Json;
+
+namespace ResgateIO.Client
+{
+    internal class RpcRequest
+    {
+        [JsonProperty(PropertyName = "id")]
+        public int Id;
+        [JsonProperty(PropertyName = "method")]
+        public string Method;
+        [JsonProperty(PropertyName = "params", NullValueHandling = NullValueHandling.Ignore)]
+        public object Params;
+        [JsonIgnore]
+        public ResponseCallback Callback;
+    }
+}

--- a/ResgateIO.Client/WebSocket.cs
+++ b/ResgateIO.Client/WebSocket.cs
@@ -8,7 +8,7 @@ namespace ResgateIO.Client
 {
     public class WebSocket : IWebSocket
     {
-        public event EventHandler<MessageEventArgs> OnMessage;
+        public event EventHandler<MessageEventArgs> MessageReceived;
         public event EventHandler OnClose;
 
         private const int ReceiveBufferSize = 8192;
@@ -115,7 +115,7 @@ namespace ResgateIO.Client
                             break;
                         }
 
-                        MessageReceived(inputStream.ToArray());
+                        OnMessageReceived(inputStream.ToArray());
                     }
                 }
             }
@@ -126,12 +126,9 @@ namespace ResgateIO.Client
             }
         }
 
-        private void MessageReceived(byte[] msg)
+        private void OnMessageReceived(byte[] msg)
         {
-            OnMessage?.Invoke(this, new MessageEventArgs
-            {
-                Message = msg
-            });
+            MessageReceived?.Invoke(this, new MessageEventArgs(msg));
         }
 
         public void Dispose()


### PR DESCRIPTION
In order to keep the end user informed about the connectivity state, an event is exposed that broadcasts changes in the connection status. By subscribing to this event, consumers of the API can provide real-time feedback to users regarding connection changes.

Apart from the main change, there is also non-functional refactorings to align the code with C# best practices and idioms.