### PR TITLE
Fix a dispose/disconnect issue and upgrade project target versions

### DIFF
--- a/ResgateIO.Client.UnitTests/ResgateIO.Client.UnitTests.csproj
+++ b/ResgateIO.Client.UnitTests/ResgateIO.Client.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>

--- a/ResgateIO.Client.UnitTests/ResgateIO.Client.UnitTests.csproj
+++ b/ResgateIO.Client.UnitTests/ResgateIO.Client.UnitTests.csproj
@@ -8,13 +8,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.6.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="1.3.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/ResgateIO.Client/ItemCache.cs
+++ b/ResgateIO.Client/ItemCache.cs
@@ -1,10 +1,10 @@
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 [assembly: InternalsVisibleTo("ResgateIO.Client.UnitTests")]
 namespace ResgateIO.Client
@@ -12,10 +12,9 @@ namespace ResgateIO.Client
 
     internal class ItemCache
     {
+        private delegate TraverseState TraverseCallback(CacheItem traversedCI, TraverseState ret);
 
-        delegate TraverseState TraverseCallback(CacheItem traversedCI, TraverseState ret);
-
-        readonly struct TraverseState
+        private readonly struct TraverseState
         {
             public readonly ReferenceState State;
             public readonly string ResourceID;
@@ -33,11 +32,11 @@ namespace ResgateIO.Client
             }
         }
 
-        private static TraverseState TraverseStop = new TraverseState(ReferenceState.Stop);
-        private static TraverseState TraverseContinue = new TraverseState(ReferenceState.None);
+        private static readonly TraverseState TraverseStop = new TraverseState(ReferenceState.Stop);
+        private static readonly TraverseState TraverseContinue = new TraverseState(ReferenceState.None);
 
-        private Dictionary<string, CacheItem> cache = new Dictionary<string, CacheItem>();
-        private object cacheLock = new object();
+        private readonly Dictionary<string, CacheItem> cache = new Dictionary<string, CacheItem>();
+        private readonly object cacheLock = new object();
         private IResourceType[] resourceTypes;
         private PatternMap<ResourceFactory> resourcePatterns;
 
@@ -208,7 +207,8 @@ namespace ResgateIO.Client
                 }
             });
 
-            await tcs.Task;
+            await tcs.Task
+                .ConfigureAwait(false);
         }
 
         public CacheItem AddResourcesAndSubscribe(JToken result, string rid)
@@ -375,7 +375,7 @@ namespace ResgateIO.Client
         private Dictionary<string, CacheItemReference> getRefState(CacheItem ci)
         {
             var refs = new Dictionary<string, CacheItemReference>();
-            
+
             // Quick exit if directly subscribed
             if (ci.Subscriptions > 0)
             {
@@ -782,7 +782,8 @@ namespace ResgateIO.Client
                 }
             }
 
-            if (reason == null) {
+            if (reason == null)
+            {
                 reason = new ResError("Missing unsubscribe reason.");
             }
 

--- a/ResgateIO.Client/ResClient.cs
+++ b/ResgateIO.Client/ResClient.cs
@@ -247,7 +247,7 @@ namespace ResgateIO.Client
 
             try
             {
-                await _rpc.WebSocket.DisconnectAsync();
+                await _rpc.DisconnectAsync();
             }
             finally
             {

--- a/ResgateIO.Client/ResClient.cs
+++ b/ResgateIO.Client/ResClient.cs
@@ -1,4 +1,11 @@
-﻿namespace ResgateIO.Client
+﻿using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace ResgateIO.Client
 {
     public class ResClient : IResClient
     {
@@ -28,7 +35,7 @@
         private int _protocol;
         private bool _isOnline;
         private bool _tryReconnect;
-        private bool _disposedValue;
+        private bool _isDisposed;
         private ItemCache _cache;
 
         /// <summary>
@@ -620,22 +627,18 @@
             _reconnectCancellationTokenSource = null;
         }
 
-        protected virtual void Dispose(bool disposing)
-        {
-            if (!_disposedValue)
-            {
-                if (disposing)
-                {
-                    _rpc?.Dispose();
-                }
-                _disposedValue = true;
-            }
-        }
-
         public void Dispose()
         {
-            Dispose(disposing: true);
-            GC.SuppressFinalize(this);
+            if (_isDisposed)
+                return;
+
+            DisposeRpc();
+
+            ResourceEvent = null;
+            Error = null;
+            ConnectionStatusChanged = null;
+
+            _isDisposed = true;
         }
     }
 }

--- a/ResgateIO.Client/ResClient.cs
+++ b/ResgateIO.Client/ResClient.cs
@@ -164,7 +164,7 @@ namespace ResgateIO.Client
 
             try
             {
-                await task;
+                await task.ConfigureAwait(false);
             }
             catch
             {
@@ -179,7 +179,8 @@ namespace ResgateIO.Client
 
         private async Task ConnectInternalAsync()
         {
-            var webSocket = await _webSocketFactory();
+            var webSocket = await _webSocketFactory()
+                .ConfigureAwait(false);
 
             webSocket.ConnectionStatusChanged += WebSocket_ConnectionStatusChanged;
 
@@ -189,11 +190,13 @@ namespace ResgateIO.Client
 
             try
             {
-                await HandshakeAsync();
+                await HandshakeAsync()
+                    .ConfigureAwait(false);
 
                 if (_onConnectCallback != null)
                 {
-                    await _onConnectCallback(this);
+                    await _onConnectCallback(this)
+                        .ConfigureAwait(false);
                 }
 
                 _isOnline = true;
@@ -239,7 +242,8 @@ namespace ResgateIO.Client
 
             try
             {
-                await _rpc.DisconnectAsync();
+                await _rpc.DisconnectAsync()
+                    .ConfigureAwait(false);
             }
             finally
             {
@@ -286,14 +290,18 @@ namespace ResgateIO.Client
             CancelOngoingReconnect();
 
             _reconnectCancellationTokenSource = new CancellationTokenSource();
-            Task.Delay(_reconnectDelay, _reconnectCancellationTokenSource.Token).ContinueWith(async _ => await Reconnect());
+            Task.Delay(
+                    _reconnectDelay,
+                    _reconnectCancellationTokenSource.Token)
+                .ContinueWith(async _ => await Reconnect().ConfigureAwait(false));
         }
 
         private async Task Reconnect()
         {
             try
             {
-                await ConnectAsync();
+                await ConnectAsync()
+                    .ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -322,7 +330,9 @@ namespace ResgateIO.Client
         /// <param name="rid">Resource ID.</param>
         public async Task UnsubscribeAsync(string rid)
         {
-            await _cache.Unsubscribe(rid, Unsubscribe);
+            await _cache
+                .Unsubscribe(rid, Unsubscribe)
+                .ConfigureAwait(false);
         }
 
         /// <summary>
@@ -433,7 +443,8 @@ namespace ResgateIO.Client
                 }
             });
 
-            return await tcs.Task;
+            return await tcs.Task
+                .ConfigureAwait(false);
         }
 
         private object HandleRequestResult(RequestResult result)
@@ -462,7 +473,9 @@ namespace ResgateIO.Client
 
         private async Task<T> RequestAsync<T>(string type, string rid, string method, object parameters)
         {
-            var o = await RequestAsync(type, rid, method, parameters);
+            var o = await RequestAsync(type, rid, method, parameters)
+                .ConfigureAwait(false);
+
             if (o is T)
             {
                 return (T)o;
@@ -521,7 +534,8 @@ namespace ResgateIO.Client
                 tcs.SetResult(null);
             });
 
-            await tcs.Task;
+            await tcs.Task
+                .ConfigureAwait(false);
         }
 
         private void Unsubscribe(string rid, ResponseCallback callback)
@@ -539,7 +553,8 @@ namespace ResgateIO.Client
 
                 try
                 {
-                    await ConnectAsync();
+                    await ConnectAsync()
+                        .ConfigureAwait(false);
                 }
                 catch (ResException e)
                 {
@@ -571,7 +586,8 @@ namespace ResgateIO.Client
         private async Task<IWebSocket> CreateWebSocket()
         {
             var webSocket = new WebSocket();
-            await webSocket.ConnectAsync(_hostUrl);
+            await webSocket.ConnectAsync(_hostUrl)
+                .ConfigureAwait(false);
             return webSocket;
         }
 

--- a/ResgateIO.Client/ResRpc.cs
+++ b/ResgateIO.Client/ResRpc.cs
@@ -138,7 +138,8 @@ namespace ResgateIO.Client
             {
                 try
                 {
-                    await _webSocket.SendAsync(dta);
+                    await _webSocket.SendAsync(dta)
+                        .ConfigureAwait(false);
                 }
                 catch (ResException e)
                 {
@@ -195,6 +196,9 @@ namespace ResgateIO.Client
 
         private void AbortPendingRequests()
         {
+            if (_requests == null)
+                return;
+
             Dictionary<int, RpcRequest> pendingRequests;
             lock (_requestLock)
             {

--- a/ResgateIO.Client/ResRpc.cs
+++ b/ResgateIO.Client/ResRpc.cs
@@ -31,13 +31,13 @@ namespace ResgateIO.Client
 
         private void WebSocket_MessageReceived(object sender, MessageEventArgs e)
         {
-            string msg = null;
-            MessageDto rpcmsg = null;
+            string message = null;
+            MessageDto rpcMessage = null;
 
             try
             {
-                msg = Encoding.UTF8.GetString(e.Message);
-                rpcmsg = JsonConvert.DeserializeObject<MessageDto>(msg);
+                message = Encoding.UTF8.GetString(e.Message);
+                rpcMessage = JsonConvert.DeserializeObject<MessageDto>(message);
             }
             catch (Exception ex)
             {
@@ -48,17 +48,17 @@ namespace ResgateIO.Client
                             e.Message, "Error deserializing incoming message.", ex)));
             }
 
-            if (rpcmsg.Id != null)
+            if (rpcMessage?.Id != null)
             {
-                HandleResponse(rpcmsg);
+                HandleResponse(rpcMessage);
             }
-            else if (rpcmsg.Event != null)
+            else if (rpcMessage?.Event != null)
             {
-                HandleEvent(rpcmsg);
+                HandleEvent(rpcMessage);
             }
             else
             {
-                throw new InvalidOperationException($"Invalid message from server: {msg}");
+                throw new InvalidOperationException($"Invalid message from server: {message}");
             }
         }
 
@@ -66,7 +66,7 @@ namespace ResgateIO.Client
         {
             try
             {
-                RpcRequest req = ConsumeRequest(message.Id ?? default);
+                var req = ConsumeRequest(message.Id ?? default);
 
                 if (message.Error != null)
                 {
@@ -138,7 +138,7 @@ namespace ResgateIO.Client
             {
                 try
                 {
-                    await this._webSocket.SendAsync(dta);
+                    await _webSocket.SendAsync(dta);
                 }
                 catch (ResException e)
                 {
@@ -157,14 +157,14 @@ namespace ResgateIO.Client
         {
             lock (_requestLock)
             {
-                if (this._requests == null)
+                if (_requests == null)
                 {
                     throw new InvalidOperationException($"Incoming request disposed: {id}");
                 }
 
-                if (this._requests.TryGetValue(id, out RpcRequest req))
+                if (_requests.TryGetValue(id, out var req))
                 {
-                    this._requests.Remove(id);
+                    _requests.Remove(id);
                     return req;
                 }
             }
@@ -188,8 +188,8 @@ namespace ResgateIO.Client
                 Dictionary<int, RpcRequest> pendingRequests;
                 lock (_requestLock)
                 {
-                    pendingRequests = this._requests;
-                    this._requests = null;
+                    pendingRequests = _requests;
+                    _requests = null;
                 }
                 foreach (var req in pendingRequests)
                 {

--- a/ResgateIO.Client/ResgateIO.Client.csproj
+++ b/ResgateIO.Client/ResgateIO.Client.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1</TargetFrameworks>
     <PackageId>ResgateIO.Client</PackageId>
     <Version>0.2.0</Version>
     <Title>RES Client .NET library</Title>

--- a/ResgateIO.Client/WebSocket.cs
+++ b/ResgateIO.Client/WebSocket.cs
@@ -35,8 +35,9 @@ namespace ResgateIO.Client
             try
             {
                 await _webSocket.ConnectAsync(
-                    new Uri(url),
-                    _cancellationTokenSource.Token);
+                        new Uri(url),
+                        _cancellationTokenSource.Token)
+                    .ConfigureAwait(false);
             }
             catch (WebSocketException ex)
             {
@@ -44,9 +45,10 @@ namespace ResgateIO.Client
             }
 
             await Task.Factory.StartNew(ReceiveLoop,
-                _cancellationTokenSource.Token,
-                TaskCreationOptions.LongRunning,
-                TaskScheduler.Default);
+                    _cancellationTokenSource.Token,
+                    TaskCreationOptions.LongRunning,
+                    TaskScheduler.Default)
+                .ConfigureAwait(false);
 
             ConnectionStatusChanged?.Invoke(
                 this,
@@ -61,9 +63,10 @@ namespace ResgateIO.Client
             _cancellationTokenSource.CancelAfter(TimeSpan.FromSeconds(2));
 
             await _webSocket.CloseAsync(
-                WebSocketCloseStatus.NormalClosure,
-                "Closing connection",
-                CancellationToken.None);
+                    WebSocketCloseStatus.NormalClosure,
+                    "Closing connection",
+                    CancellationToken.None)
+                .ConfigureAwait(false);
 
             ConnectionStatusChanged?.Invoke(
                 this,
@@ -80,10 +83,11 @@ namespace ResgateIO.Client
             try
             {
                 await _webSocket.SendAsync(
-                    new ArraySegment<byte>(data),
-                    WebSocketMessageType.Binary,
-                    true,
-                    CancellationToken.None);
+                        new ArraySegment<byte>(data),
+                        WebSocketMessageType.Binary,
+                        true,
+                        CancellationToken.None)
+                    .ConfigureAwait(false);
             }
             catch (WebSocketException ex)
             {
@@ -104,8 +108,9 @@ namespace ResgateIO.Client
                         do
                         {
                             receiveResult = await _webSocket.ReceiveAsync(
-                                new ArraySegment<byte>(buffer),
-                                _cancellationTokenSource.Token);
+                                    new ArraySegment<byte>(buffer),
+                                    _cancellationTokenSource.Token)
+                                .ConfigureAwait(false);
 
                             if (receiveResult.MessageType != WebSocketMessageType.Close)
                                 inputStream.Write(buffer, 0, receiveResult.Count);


### PR DESCRIPTION
- Fix a problem with the dispose/disconnect functionality.
- Add `ConfigureAwait(false)` to all awaited calls for library gygiene
- Upgrade test project to .NET 8 LTS + most recent NuGet packages
- Upgrade main project to .NET Standard 2.1 (eventually aiming for IAsyncDisposable)
- Minor style related changes